### PR TITLE
add codecov config

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - "main.go"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mrwormhole/laverna
 
-go 1.24
+go 1.25
 
 toolchain go1.25.0
 


### PR DESCRIPTION
adds codecov config to exclude main.go file, it is a common practice to keep main.go files short and concise while excluding from code coverage